### PR TITLE
Adds use-package installation instructions for futuro's fork

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,7 +15,14 @@ interactive selection in case of conflicts.
 
 ** Installation
 
-   Installation instructions forthcoming.
+   #+begin_src elisp
+     (use-package auth-source-1password
+       :vc (:url "https://github.com/futuro/auth-source-1password"
+                 :branch "main")
+       :variables
+       auth-source-1password-vault "Personal")
+   #+end_src
+
 
 ** Usage
 


### PR DESCRIPTION
I had just fixed auth-source-1password to work with `^` characters, basically the same way you did, and was about to fork upstream so I could share my fix. I appreciate that you already did the same thing just weeks earlier!

I recommend that you open a pull request with upstream, this is a useful update. In the meantime, I offer install instructions for folks who want to use `use-package` to grab your version of the software.

Cheers!